### PR TITLE
PadEnd with 0 when code is less than 6 digits

### DIFF
--- a/src/lib/auth.js
+++ b/src/lib/auth.js
@@ -4,7 +4,7 @@ import { parse } from "./cookie";
 export function generateVerificationCode() {
   var vals = new Uint8Array(3);
   crypto.getRandomValues(vals);
-  return ((vals[0] & 255) * 100000 + (vals[1] & 255) * 1000 + (vals[2] & 255)).toString().slice(0, 6);
+  return ((vals[0] & 255) * 100000 + (vals[1] & 255) * 1000 + (vals[2] & 255)).toString().slice(0, 6).padEnd(6,"0");
 }
 
 export async function hashSessionToken(token) {


### PR DESCRIPTION
Few rare cases the code might return 2 digits. In those cases add zeroes for the rest so that we ensure 6 digits always.